### PR TITLE
Implement feed search

### DIFF
--- a/dynastart.html
+++ b/dynastart.html
@@ -45,6 +45,10 @@
     <div class="container mt-2">
         <input type="search" id="searchInput" class="form-control py-2 rounded-pill mr-1 pr-5" placeholder="Search: type to search title and body, '!title' for title only, '#tooltip' for tooltip only, '>external' for external search">
     </div>
+    <!-- RSS Feed Search Bar, visible when a feed is displayed -->
+    <div class="container mt-2" id="feedSearchContainer" style="display: none;">
+        <input type="search" id="feedSearchInput" class="form-control py-2 rounded-pill mr-1 pr-5" placeholder="Search in feed">
+    </div>
     <!-- Main content area for displaying links -->
     <div class="container mt-5" id="linksContainer">
       <!-- Links will be inserted here using JavaScript -->

--- a/js/dynastart.js
+++ b/js/dynastart.js
@@ -9,6 +9,7 @@ let tagLength = 6;
 let selectedFixedTags = new Set(); // Keep track of Fixed tags
 let selectedTags = new Set();  // Keep track of secondary tags
 let debug = false; // Global debug flag
+let currentFeedItems = null; // Holds items when viewing an RSS feed
 
 /**
  * Logs debug information to the console if the debug flag is set.
@@ -307,6 +308,8 @@ function toggleTagSelection(linkElement, tag) {
  * or displays clicked links sorted by the number of clicks if no tags are selected.
  */
 function filterLinksByTags() {
+    currentFeedItems = null;
+    document.getElementById('feedSearchContainer').style.display = 'none';
     selectedLinks = [];
     let tagselectedLinks = [];
     let allLinks = getAlllinks();
@@ -467,6 +470,9 @@ async function fetchRssFeed(url) {
             openInTab: true,
             rssfeed: false
         }));
+        currentFeedItems = items;
+        document.getElementById('feedSearchContainer').style.display = 'block';
+        document.getElementById('feedSearchInput').value = '';
         displayLinks(items);
     } catch (err) {
         console.error('Failed to fetch RSS feed', err);
@@ -848,8 +854,21 @@ function external_search() {
     }
 }
 
+// Filter currently displayed RSS feed items based on feed search box
+function filterCurrentFeed() {
+    if (!currentFeedItems) return;
+    const query = document.getElementById('feedSearchInput').value.toLowerCase();
+    const filtered = currentFeedItems.filter(item =>
+        item.title.toLowerCase().includes(query) || item.tooltip.toLowerCase().includes(query)
+    );
+    displayLinks(filtered);
+}
+
 // Event listener for the search input field
 document.getElementById('searchInput').addEventListener('input', filterLinksByTags);
+
+// Event listener for RSS feed search box
+document.getElementById('feedSearchInput').addEventListener('input', filterCurrentFeed);
 
 // Event listener for the Enter key in the search input field
 document.getElementById('searchInput').addEventListener('keypress', function(event) {


### PR DESCRIPTION
## Summary
- add hidden search bar for RSS feed results
- filter RSS feed items as user types
- show/hide feed search on feed load or return to normal view

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841f3b195b4832487b7a0df44c5aaac